### PR TITLE
fix: correct casing of NoTimeStamp parameter in saveToDailyNoteTool

### DIFF
--- a/src/tools/saveToDailyNote.test.ts
+++ b/src/tools/saveToDailyNote.test.ts
@@ -17,7 +17,7 @@ describe("saveToDailyNoteTool", () => {
 		expect(saveToDailyNoteTool.parameters.shape.spaceId).toBeDefined();
 		expect(saveToDailyNoteTool.parameters.shape.mdText).toBeDefined();
 		expect(saveToDailyNoteTool.parameters.shape.origin.isOptional()).toBe(true);
-		expect(saveToDailyNoteTool.parameters.shape.noTimestamp.isOptional()).toBe(
+		expect(saveToDailyNoteTool.parameters.shape.NoTimeStamp.isOptional()).toBe(
 			true,
 		);
 		expect(typeof saveToDailyNoteTool.execute).toBe("function");

--- a/src/tools/saveToDailyNote.ts
+++ b/src/tools/saveToDailyNote.ts
@@ -12,15 +12,15 @@ export const saveToDailyNoteTool = {
 		spaceId: string;
 		mdText: string;
 		origin?: "commandPalette";
-		noTimestamp?: boolean;
+		NoTimeStamp?: boolean; // <-- changed here
 	}) => {
 		try {
 			const requestBody = {
 				spaceId: args.spaceId,
 				mdText: args.mdText,
 				...(args.origin && { origin: args.origin }),
-				...(args.noTimestamp !== undefined && {
-					noTimestamp: args.noTimestamp,
+				...(args.NoTimeStamp !== undefined && {
+					NoTimeStamp: args.NoTimeStamp, // <-- changed here
 				}),
 			};
 
@@ -63,7 +63,7 @@ export const saveToDailyNoteTool = {
 			.describe(
 				"Optional origin label for the content (only 'commandPalette' is supported)",
 			),
-		noTimestamp: z
+		NoTimeStamp: z // <-- changed here
 			.boolean()
 			.optional()
 			.describe("If true, no time stamp will be added to the note"),


### PR DESCRIPTION
When attempting to use the NoTimeStamp parameter for daily notes it was failing to not add a timestame into Capacities. I believe it is because of the incorrect casing on the parameter. 

