### PR TITLE
Add readObjectContent tool for retrieving full note content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,10 +32,15 @@ cp .env.example .env
 - `capacities_get_space_info` - Get structures and collections for a space
 - `capacities_search` - Search content across spaces
   - `mode` defaults to "title" if not specified
+- `capacities_read_object_content` - Retrieve full content of an object by ID
+  - Parameters: `objectId` (UUID), `spaceId` (UUID), `title` (optional string)
+  - How it works: Tries undocumented endpoints first, then falls back to search API aggregation
+  - Note: Providing `title` parameter greatly improves search results
+  - Returns aggregated content from search snippets when direct endpoint unavailable
 - `capacities_save_weblink` - Save a web link to a space
   - Parameters: `titleOverwrite`, `descriptionOverwrite`, `tags`, `mdText`
 - `capacities_save_to_daily_note` - Add text to today's daily note
-  - `origin` only accepts "commandPalette" 
+  - `origin` only accepts "commandPalette"
   - Use `noTimestamp: true` to skip timestamp
 
 ## Available Prompts

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This MCP server provides access to all current Capacities API endpoints:
 - **List Spaces** - Get all your personal spaces
 - **Space Information** - Retrieve detailed space structures and collections
 - **Search Content** - Search across spaces with advanced filtering
+- **Read Object Content** - Retrieve full note content by object ID (uses search API workaround)
 - **Save Weblinks** - Save URLs to your spaces with metadata
 - **Daily Notes** - Add content to your daily notes
 
@@ -143,6 +144,17 @@ Add markdown content to today's daily note in a space.
 - **mdText**: Markdown content to add
 - **origin** (optional): Origin label for the content (only "commandPalette" is supported)
 - **noTimestamp** (optional): If true, no timestamp will be added to the note
+
+### `capacities_read_object_content`
+Retrieve the full content of a Capacities object by its ID.
+- **objectId**: UUID of the object to retrieve (can be obtained from 'Copy object reference' in Capacities)
+- **spaceId**: UUID of the space containing the object
+- **title** (optional): The title or partial title of the object - strongly recommended to improve search results
+- **How it works**:
+  1. First attempts to use undocumented GET endpoints for direct object retrieval
+  2. Falls back to search API, aggregating content from highlights and snippets
+  3. Filters search results by object ID to find exact match
+- **Note**: When using search fallback, content may be incomplete as it's assembled from search snippets. Providing the title parameter significantly improves results.
 
 ## Rate Limits
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import { FastMCP } from "fastmcp";
 import {
 	getSpaceInfoTool,
 	listSpacesTool,
+	readObjectContentTool,
 	saveToDailyNoteTool,
 	saveWeblinkTool,
 	searchTool,
@@ -24,6 +25,7 @@ const server = new FastMCP({
 server.addTool(listSpacesTool);
 server.addTool(getSpaceInfoTool);
 server.addTool(searchTool);
+server.addTool(readObjectContentTool);
 server.addTool(saveWeblinkTool);
 server.addTool(saveToDailyNoteTool);
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,3 +3,4 @@ export { getSpaceInfoTool } from "./getSpaceInfo.js";
 export { searchTool } from "./search.js";
 export { saveWeblinkTool } from "./saveWeblink.js";
 export { saveToDailyNoteTool } from "./saveToDailyNote.js";
+export { readObjectContentTool } from "./readObjectContent.js";

--- a/src/tools/readObjectContent.test.ts
+++ b/src/tools/readObjectContent.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { readObjectContentTool } from "./readObjectContent.js";
+
+describe("readObjectContentTool", () => {
+	test("should have correct metadata", () => {
+		expect(readObjectContentTool.name).toBe("capacities_read_object_content");
+		expect(readObjectContentTool.description).toContain(
+			"Retrieve the full content",
+		);
+		expect(readObjectContentTool.annotations.readOnlyHint).toBe(true);
+		expect(readObjectContentTool.annotations.openWorldHint).toBe(true);
+		expect(readObjectContentTool.annotations.title).toBe("Read Object Content");
+	});
+
+	test("should have correct parameter schema", () => {
+		expect(readObjectContentTool.parameters).toBeDefined();
+		expect(typeof readObjectContentTool.execute).toBe("function");
+
+		// Validate that parameters require objectId and spaceId
+		const params = readObjectContentTool.parameters.shape;
+		expect(params.objectId).toBeDefined();
+		expect(params.spaceId).toBeDefined();
+	});
+});

--- a/src/tools/readObjectContent.ts
+++ b/src/tools/readObjectContent.ts
@@ -1,0 +1,205 @@
+import { z } from "zod";
+import { API_BASE_URL, getApiKey } from "../api.js";
+
+export const readObjectContentTool = {
+	annotations: {
+		openWorldHint: true,
+		readOnlyHint: true,
+		title: "Read Object Content",
+	},
+	description:
+		"Retrieve the full content of a Capacities object by its ID. Optionally provide a title or search term to improve results. This tries undocumented endpoints first, then falls back to search API aggregation.",
+	execute: async (args: {
+		objectId: string;
+		spaceId: string;
+		title?: string;
+	}) => {
+		const apiKey = getApiKey();
+
+		// Try potential undocumented endpoints first
+		const potentialEndpoints = [
+			`/object/${args.objectId}`,
+			`/objects/${args.objectId}`,
+			`/content/${args.objectId}`,
+			`/space/${args.spaceId}/object/${args.objectId}`,
+		];
+
+		for (const endpoint of potentialEndpoints) {
+			try {
+				const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+					headers: {
+						Authorization: `Bearer ${apiKey}`,
+						"Content-Type": "application/json",
+					},
+				});
+
+				if (response.ok) {
+					const data = await response.json();
+					return JSON.stringify(
+						{
+							note: `Successfully retrieved from undocumented endpoint: ${endpoint}`,
+							object: data,
+						},
+						null,
+						2,
+					);
+				}
+			} catch (error) {
+				// Continue to next endpoint
+			}
+		}
+
+		// Fallback to search API approach
+		try {
+			// Search using title if provided, otherwise use a wildcard search
+			const searchTerm = args.title || "*";
+
+			const requestBody = {
+				searchTerm: searchTerm,
+				spaceIds: [args.spaceId],
+				mode: "fullText" as const,
+			};
+
+			const searchResponse = await fetch(`${API_BASE_URL}/search`, {
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify(requestBody),
+			});
+
+			if (!searchResponse.ok) {
+				throw new Error(
+					`Search API error: ${searchResponse.status} ${searchResponse.statusText}`,
+				);
+			}
+
+			const data = (await searchResponse.json()) as {
+				results?: Array<{
+					id?: string;
+					title?: string;
+					highlights?: Array<{
+						snippets?: string[];
+						context?: { field?: string; [key: string]: unknown };
+						score?: number;
+						[key: string]: unknown;
+					}>;
+					snippet?: string;
+					[key: string]: unknown;
+				}>;
+			};
+
+			if (!data || !data.results || data.results.length === 0) {
+				return JSON.stringify(
+					{
+						error: "Object not found",
+						message: `No results found. Try providing the 'title' parameter to search for the object.`,
+						searchTerm: searchTerm,
+					},
+					null,
+					2,
+				);
+			}
+
+			// Find the exact match by ID
+			const exactMatch = data.results.find(
+				(result) => result.id === args.objectId,
+			);
+
+			if (!exactMatch) {
+				return JSON.stringify(
+					{
+						error: "Object not found by ID",
+						message: `Found ${data.results.length} results but none matched object ID ${args.objectId}. Try searching by title first.`,
+						availableResults: data.results.map((r) => ({
+							id: r.id,
+							title: r.title,
+						})),
+					},
+					null,
+					2,
+				);
+			}
+
+			// Aggregate content from highlights and snippets
+			const aggregatedContent: string[] = [];
+
+			// Try to extract snippet
+			if (exactMatch.snippet && typeof exactMatch.snippet === "string") {
+				aggregatedContent.push(exactMatch.snippet);
+			}
+
+			// Extract from highlights array - each highlight has a snippets array
+			if (exactMatch.highlights && Array.isArray(exactMatch.highlights)) {
+				for (const highlight of exactMatch.highlights) {
+					// The highlight object has a "snippets" array containing the actual text
+					if (highlight.snippets && Array.isArray(highlight.snippets)) {
+						for (const snippet of highlight.snippets) {
+							if (typeof snippet === "string" && snippet.trim()) {
+								aggregatedContent.push(snippet);
+							}
+						}
+					}
+				}
+			}
+
+			// Also try other common content fields on the result object
+			const otherContentFields = [
+				"content",
+				"text",
+				"body",
+				"description",
+				"mdText",
+			];
+			for (const field of otherContentFields) {
+				const value = exactMatch[field];
+				if (value && typeof value === "string" && value.trim()) {
+					aggregatedContent.push(`[${field}]: ${value}`);
+				}
+			}
+
+			return JSON.stringify(
+				{
+					note: "Content retrieved via search API. This may be incomplete - search only returns snippets/highlights.",
+					object: {
+						id: exactMatch.id,
+						title: exactMatch.title,
+						aggregatedContent:
+							aggregatedContent.length > 0
+								? aggregatedContent.join("\n\n---\n\n")
+								: "No content snippets available",
+						snippetCount: aggregatedContent.length,
+						highlights: exactMatch.highlights,
+						rawResult: exactMatch,
+					},
+				},
+				null,
+				2,
+			);
+		} catch (error) {
+			throw new Error(
+				`Failed to read object content: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	},
+	name: "capacities_read_object_content",
+	parameters: z.object({
+		objectId: z
+			.string()
+			.uuid()
+			.describe(
+				"The UUID of the object to retrieve. You can get this from 'Copy object reference' in Capacities.",
+			),
+		spaceId: z
+			.string()
+			.uuid()
+			.describe("The UUID of the space containing the object"),
+		title: z
+			.string()
+			.optional()
+			.describe(
+				"Optional: The title or partial title of the object to search for. This improves search results.",
+			),
+	}),
+};


### PR DESCRIPTION
## Overview
Adds a new `readObjectContent` tool that retrieves full object content from Capacities.

## Implementation
- Attempts undocumented API endpoints first (`/object/{id}`, `/objects/{id}`, etc.)
- Falls back to search API with intelligent snippet aggregation
- Properly extracts and combines content from `highlights[].snippets[]` arrays
- Supports optional `title` parameter for improved search accuracy

## Why This is Needed
The existing search tool only returns snippets/highlights. This tool aggregates all available snippets to provide more complete content retrieval until Capacities officially documents a read endpoint.

## Testing
Tested successfully with multiple note types, confirmed proper snippet aggregation and content extraction.